### PR TITLE
refactor(helm): unify ingress configuration using depServices.class-443

### DIFF
--- a/agent-app/helm/agent-app/templates/ingress.yaml
+++ b/agent-app/helm/agent-app/templates/ingress.yaml
@@ -10,9 +10,7 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/service-upstream: "true" # 使用客户端源ip
 spec:
-{{- if .Values.service.ingressclassname }}
-  ingressClassName: "{{.Values.service.ingressclassname}}"
-{{- end }}
+  ingressClassName: {{ index .Values.depServices "class-443" "ingressClass" }}
   rules:
   - http:
       paths:

--- a/agent-app/helm/agent-app/values.yaml
+++ b/agent-app/helm/agent-app/values.yaml
@@ -22,7 +22,6 @@ image:
     pullPolicy: IfNotPresent
 
 service:
-  ingressclassname: "class-443"
   agentApp:
     type: ClusterIP
     port: 30777
@@ -56,6 +55,8 @@ env:
   timezone: Asia/Shanghai
 
 depServices:
+  class-443:
+    ingressClass: class-443
   hydra:
     userMgnt:
       host: user-management-private

--- a/agent-executor/helm/agent-executor/templates/ingress.yaml
+++ b/agent-executor/helm/agent-executor/templates/ingress.yaml
@@ -9,9 +9,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: "500M"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
-{{- if .Values.service.ingressclassname }}
-  ingressClassName: "{{.Values.service.ingressclassname}}"
-{{- end }}
+  ingressClassName: {{ index .Values.depServices "class-443" "ingressClass" }}
   rules:
   - http:
       paths:

--- a/agent-executor/helm/agent-executor/values.yaml
+++ b/agent-executor/helm/agent-executor/values.yaml
@@ -12,7 +12,6 @@ image:
   name: agent-executor
 
 service:
-  ingressclassname: ""
   AgentExecutor:
     type: ClusterIP
     port: 30778
@@ -92,6 +91,8 @@ probe:
 nodeSelector: { }
 
 depServices:
+  class-443:
+    ingressClass: class-443
   rds:
     host: "rds-proton-rds-mariadb-cluster"
     port: "3320"

--- a/agent-factory/helm/agent-factory/templates/ingress.yaml
+++ b/agent-factory/helm/agent-factory/templates/ingress.yaml
@@ -9,9 +9,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: "500M"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
-{{- if .Values.service.ingressclassname }}
-  ingressClassName: "{{.Values.service.ingressclassname}}"
-{{- end }}
+  ingressClassName: {{ index .Values.depServices "class-443" "ingressClass" }}
   rules:
   - http:
       paths:

--- a/agent-factory/helm/agent-factory/values.yaml
+++ b/agent-factory/helm/agent-factory/values.yaml
@@ -21,7 +21,6 @@ image:
     pullPolicy: IfNotPresent
 
 service:
-  ingressclassname: "class-443"
   agentFactory:
     type: ClusterIP
     port: 13020
@@ -52,6 +51,8 @@ env:
   disable_pms_check: false
 
 depServices:
+  class-443:
+    ingressClass: class-443
   hydra:
     userMgnt:
       host: user-management-private

--- a/agent-memory/helm/.gitignore
+++ b/agent-memory/helm/.gitignore
@@ -1,0 +1,1 @@
+helm-template-gen.yaml

--- a/agent-memory/helm/Makefile
+++ b/agent-memory/helm/Makefile
@@ -1,0 +1,5 @@
+test:
+	helm template agent-memory --name-template "agent-memory">./helm-template-gen.yaml
+
+lint:
+	cd agent-memory && helm lint .

--- a/agent-memory/helm/agent-memory/templates/ingress.yaml
+++ b/agent-memory/helm/agent-memory/templates/ingress.yaml
@@ -9,9 +9,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: "500M"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
-{{- if .Values.service.ingressclassname }}
-  ingressClassName: "{{.Values.service.ingressclassname}}"
-{{- end }}
+  ingressClassName: {{ index .Values.depServices "class-443" "ingressClass" }}
   rules:
   - http:
       paths:

--- a/agent-memory/helm/agent-memory/values.yaml
+++ b/agent-memory/helm/agent-memory/values.yaml
@@ -18,7 +18,6 @@ env:
   embedding_model_dims: 768
 
 service:
-  ingressclassname: "class-443"
   agentMemory:
     type: ClusterIP
     port: 30790
@@ -80,6 +79,8 @@ probe:
 nodeSelector: { }
 
 depServices:
+  class-443:
+    ingressClass: class-443
   rds:
     type: MYSQL
     host: mariadb-mariadb-cluster.resource

--- a/agent-web/charts/.gitignore
+++ b/agent-web/charts/.gitignore
@@ -1,0 +1,1 @@
+helm-template-gen.yaml

--- a/agent-web/charts/Makefile
+++ b/agent-web/charts/Makefile
@@ -1,0 +1,5 @@
+test:
+	helm template agent-web --name-template "agent-web">./helm-template-gen.yaml
+
+lint:
+	cd agent-web && helm lint .


### PR DESCRIPTION
- Replace service.ingressclassname with depServices.class-443.ingressClass
- Update ingress templates to use {{ index .Values.depServices "class-443" "ingressClass" }}
- Remove deprecated service.ingressclassname from values.yaml files
- Add Makefile and .gitignore for agent-memory/helm and agent-web/charts
- Affected services: agent-app, agent-executor, agent-factory, agent-memory, agent-web