### PR TITLE
```

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,33 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, ' /oc') ||
+      startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /opencode') ||
+      startsWith(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
+        with:
+          model: zhipuai-coding-plan/glm-4.7


### PR DESCRIPTION
feat(workflow): add opencode GitHub Actions workflow

Add a new GitHub Actions workflow that enables opencode functionality through issue comments and PR review comments.

The workflow:
- Triggers on issue_comment and pull_request_review_comment events
- Responds to commands like '/oc', ' /oc', '/opencode', ' /opencode'
- Uses anomalyco/opencode/github action with zhipuai-coding-plan/glm-4.7 model
- Requires ZHIPU_API_KEY secret for authentication
- Runs on ubuntu-latest with appropriate permissions for content access
```