### PR TITLE
fix: 修复对话错误后在历史对话列表查看的时候无法显示错误对话的问题

### DIFF
--- a/agent-backend/agent-factory/src/domain/service/agentrunsvc/chat_post_process.go
+++ b/agent-backend/agent-factory/src/domain/service/agentrunsvc/chat_post_process.go
@@ -204,7 +204,7 @@ func (agentSvc *agentSvc) AfterProcess(ctx context.Context, callResult []byte, r
 		if v, ok := progressMap.Load(req.AssistantMessageID); ok {
 			if pgs, ok := v.([]*agentrespvo.Progress); ok {
 				progressAns = pgs
-				agentSvc.logger.Infof("[AfterProcess] status is Error, loaded progress from progressMap, count: %d", len(progressAns))
+				agentSvc.logger.Debugf("[AfterProcess] status is Error, loaded progress from progressMap, count: %d", len(progressAns))
 			} else {
 				agentSvc.logger.Warnf("[AfterProcess] progressMap has wrong type for assistantMessageID: %s", req.AssistantMessageID)
 				// 提供回退机制：创建一个默认的progress对象
@@ -213,7 +213,7 @@ func (agentSvc *agentSvc) AfterProcess(ctx context.Context, callResult []byte, r
 						ID:     "fallback-" + req.AssistantMessageID,
 						Status: "failed",
 						Answer: map[string]interface{}{
-							"text": "处理过程中出现错误",
+							"text": "[AfterProcess] agent error, please try again",
 						},
 					},
 				}
@@ -221,14 +221,14 @@ func (agentSvc *agentSvc) AfterProcess(ctx context.Context, callResult []byte, r
 			// 清理progressMap，避免内存泄漏
 			progressMap.Delete(req.AssistantMessageID)
 		} else {
-			agentSvc.logger.Infof("[AfterProcess] status is Error, progressMap is empty for assistantMessageID: %s", req.AssistantMessageID)
+			agentSvc.logger.Debugf("[AfterProcess] status is Error, progressMap is empty for assistantMessageID: %s", req.AssistantMessageID)
 			// 提供回退机制：创建一个默认的progress对象
 			progressAns = []*agentrespvo.Progress{
 				{
 					ID:     "fallback-" + req.AssistantMessageID,
 					Status: "failed",
 					Answer: map[string]interface{}{
-						"text": "处理过程中出现错误",
+						"text": "[AfterProcess] agent error, please try again",
 					},
 				},
 			}


### PR DESCRIPTION
## 1. 变更说明（Purpose） 这个 PR 解决了什么问题、实现了什么功能？
- 解决的问题：
  1. 对话出错时，从历史对话查看时 middle_answer.progress 为空
  2. 对话出错时，从历史对话查看时错误详情丢失
- 实现功能：
  1. 确保对话出错时 progress 数据被正确保存
  2. 确保对话出错时错误详情被正确保存到消息的 Ext.Error 字段
- 关联 Issue：#86
## 2. 修改类型（Type of Change）
- Bug 修复
## 3. 实现方案（How & Why） 关键逻辑、技术方案、为什么这么改
1. 问题1：progress 数据为空
   
   - 原因：当状态为 Error 时，progressAns 为空，没有从 progressMap 中获取数据
   - 解决方案：在 AfterProcess 函数中添加代码，当 result.Status == "Error" && len(progressAns) == 0 时，从 progressMap 中加载 progress 数据
   - 代码位置： agent-backend/agent-factory/src/domain/service/agentrunsvc/chat_post_process.go:201-209
2. 问题2：错误详情丢失
   
   - 原因：错误信息 ( result.Error ) 只是在内存中设置到 chatResponse.Error ，但没有保存到消息的 Ext.Error 字段
   - 解决方案：
     - 添加 convertErrorToRespError 辅助函数，将 result.Error 转换为 *agentresperr.RespError 类型
     - 在 messageVO.Ext 中设置错误信息： Error: convertErrorToRespError(result.Error)
   - 代码位置：
     - 辅助函数： agent-backend/agent-factory/src/domain/service/agentrunsvc/chat_post_process.go:493-506
     - 错误信息设置： agent-backend/agent-factory/src/domain/service/agentrunsvc/chat_post_process.go:277
## 4. 自测清单（Self Check）
- 本地编译/运行通过
- 新增/修改了测试用例
- 已验证功能正常
- 无日志/异常/报错
- 兼容相关场景
## 5. 截图/日志（可选） 界面、接口返回、性能对比等
测试通过日志：

```
--- PASS: TestAfterProcess_StatusError_Full (0.05s)
--- PASS: TestAfterProcess_StatusError_WithErrorCode (0.05s)
PASS
ok      github.com/kweaver-ai/decision-agent/agent-factory/src/
domain/service/agentrunsvc       0.086s
```
## 6. 检查项（Reviewer 用）
- 代码逻辑清晰
- 命名规范、无冗余代码
- 安全/权限无问题
- 符合团队编码规范
- 合并不会影响主分支
## 7. 备注（Notes） 需要注意的点、依赖、部署说明、风险点
- 本次修改只涉及错误处理路径的改进，不影响正常对话流程
- 已确保与现有代码的兼容性
- 测试覆盖了错误场景，确保功能正常