### PR TITLE
fix: support umbrella chart naming for decision-agent charts

### DIFF
--- a/agent-backend/deploy/helm/agent-backend/templates/_helpers.tpl
+++ b/agent-backend/deploy/helm/agent-backend/templates/_helpers.tpl
@@ -1,0 +1,105 @@
+{{/* vim: set filetype=mustache: */}}
+
+
+{{/* ========== Universal Global Values Merge Helpers ========== */}}
+{{/* All charts use these same helper function names for consistency */}}
+
+{{- define "mergedGlobalValues.imageRegistry" -}}
+{{- $globalImage := (.Values.global | default dict).image | default dict -}}
+{{- if $globalImage.registry -}}
+{{- $globalImage.registry -}}
+{{- else -}}
+{{- .Values.image.registry -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.replicaCount" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "replicaCount" -}}
+{{- $global.replicaCount -}}
+{{- else -}}
+{{- .Values.replicaCount -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.env" -}}
+{{- $globalEnv := (.Values.global | default dict).env | default dict -}}
+{{- if $globalEnv -}}
+{{- toYaml (mergeOverwrite (deepCopy (.Values.env | default dict)) $globalEnv) -}}
+{{- else -}}
+{{- toYaml .Values.env -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.depServices" -}}
+{{- $globalDeps := (.Values.global | default dict).depServices | default dict -}}
+{{- if $globalDeps -}}
+{{- toYaml (mergeOverwrite (deepCopy (.Values.depServices | default dict)) $globalDeps) -}}
+{{- else -}}
+{{- toYaml .Values.depServices -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.imagePullSecrets" -}}
+{{- $localSecrets := .Values.imagePullSecrets | default (list) -}}
+{{- $globalSecrets := (.Values.global | default dict).imagePullSecrets | default (list) -}}
+{{- if gt (len $localSecrets) 0 -}}
+{{- toYaml $localSecrets -}}
+{{- else if gt (len $globalSecrets) 0 -}}
+{{- toYaml $globalSecrets -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.namespace" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "namespace" -}}
+{{- $global.namespace -}}
+{{- else -}}
+{{- .Values.namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.mode" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "mode" -}}
+{{- $global.mode -}}
+{{- else -}}
+{{- .Values.mode | default "Community" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.accessAddress" -}}
+{{- $globalAccess := (.Values.global | default dict).accessAddress | default dict -}}
+{{- if $globalAccess -}}
+{{- toYaml (mergeOverwrite (deepCopy (.Values.accessAddress | default dict)) $globalAccess) -}}
+{{- else -}}
+{{- toYaml .Values.accessAddress -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.ingressClassName" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "ingressClassName" -}}
+{{- $global.ingressClassName -}}
+{{- else -}}
+{{- .Values.ingressClassName | default "nginx" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.flowAutomation" -}}
+{{- $globalFlow := (.Values.global | default dict).flowAutomation | default dict -}}
+{{- if $globalFlow -}}
+{{- toYaml (mergeOverwrite (deepCopy (.Values.flowAutomation | default dict)) $globalFlow) -}}
+{{- else -}}
+{{- toYaml .Values.flowAutomation -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.image" -}}
+{{- $imageRegistry := include "mergedGlobalValues.imageRegistry" . -}}
+{{- if $imageRegistry }}
+{{- printf "%s/%s:%s" $imageRegistry .Values.image.repository .Values.image.tag -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+{{- end -}}

--- a/agent-backend/deploy/helm/agent-backend/templates/configmap-executor.yaml
+++ b/agent-backend/deploy/helm/agent-backend/templates/configmap-executor.yaml
@@ -1,10 +1,11 @@
 # Agent Executor ConfigMap V2 (yaml配置文件)
 # 从老Chart复制，修改name为固定值
+{{ $depServices := include "mergedGlobalValues.depServices" . | fromYaml }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: agent-executor-yaml
-  namespace: {{ .Values.namespace }}
+  name: agent-backend-executor-yaml
+  namespace: {{ .Release.Namespace }}
 data:
   agent-executor.yaml: |
     # agent-executor v2版本配置文件
@@ -31,60 +32,60 @@ data:
 
     # 2. 结构化数据库相关
     rds:
-      host: {{ .Values.depServices.rds.host | quote }}
-      port: {{ .Values.depServices.rds.port }}
-      dbname: {{ .Values.depServices.rds.database | quote }}
-      user: {{ .Values.depServices.rds.user | quote }}
-      password: {{ .Values.depServices.rds.password | quote }}
-      db_type: {{ .Values.depServices.rds.type | quote }}
+      host: {{ $depServices.rds.host | quote }}
+      port: {{ $depServices.rds.port }}
+      dbname: {{ $depServices.rds.database | quote }}
+      user: {{ $depServices.rds.user | quote }}
+      password: {{ $depServices.rds.password | quote }}
+      db_type: {{ $depServices.rds.type | quote }}
 
     # 3. redis数据库相关
     redis:
       # 连接类型: standalone, sentinel, master-slave
-      cluster_mode: {{ .Values.depServices.redis.connectType | quote }}
-      {{- if eq .Values.depServices.redis.connectType "sentinel" }}
+      cluster_mode: {{ $depServices.redis.connectType | quote }}
+      {{- if eq $depServices.redis.connectType "sentinel" }}
       # sentinel模式配置
-      host: {{ .Values.depServices.redis.connectInfo.sentinelHost | quote }}
-      port: {{ .Values.depServices.redis.connectInfo.sentinelPort | quote }}
-      user: {{ .Values.depServices.redis.connectInfo.username | quote }}
-      password: {{ .Values.depServices.redis.connectInfo.password | quote }}
-      sentinel_master: {{ .Values.depServices.redis.connectInfo.masterGroupName | quote }}
-      sentinel_user: {{ .Values.depServices.redis.connectInfo.sentinelUsername | quote }}
-      sentinel_password: {{ .Values.depServices.redis.connectInfo.sentinelPassword | quote }}
-      {{- else if eq .Values.depServices.redis.connectType "standalone" }}
+      host: {{ $depServices.redis.connectInfo.sentinelHost | quote }}
+      port: {{ $depServices.redis.connectInfo.sentinelPort | quote }}
+      user: {{ $depServices.redis.connectInfo.username | quote }}
+      password: {{ $depServices.redis.connectInfo.password | quote }}
+      sentinel_master: {{ $depServices.redis.connectInfo.masterGroupName | quote }}
+      sentinel_user: {{ $depServices.redis.connectInfo.sentinelUsername | quote }}
+      sentinel_password: {{ $depServices.redis.connectInfo.sentinelPassword | quote }}
+      {{- else if eq $depServices.redis.connectType "standalone" }}
       # standalone模式配置
-      host: {{ .Values.depServices.redis.connectInfo.host | quote }}
-      port: {{ .Values.depServices.redis.connectInfo.port | quote }}
-      user: {{ .Values.depServices.redis.connectInfo.username | quote }}
-      password: {{ .Values.depServices.redis.connectInfo.password | quote }}
-      {{- else if eq .Values.depServices.redis.connectType "master-slave" }}
+      host: {{ $depServices.redis.connectInfo.host | quote }}
+      port: {{ $depServices.redis.connectInfo.port | quote }}
+      user: {{ $depServices.redis.connectInfo.username | quote }}
+      password: {{ $depServices.redis.connectInfo.password | quote }}
+      {{- else if eq $depServices.redis.connectType "master-slave" }}
       # master-slave模式配置
-      read_host: {{ .Values.depServices.redis.connectInfo.slaveHost | quote }}
-      read_port: {{ .Values.depServices.redis.connectInfo.slavePort | quote }}
-      read_user: {{ .Values.depServices.redis.connectInfo.username | quote }}
-      read_password: {{ .Values.depServices.redis.connectInfo.password | quote }}
-      write_host: {{ .Values.depServices.redis.connectInfo.masterHost | quote }}
-      write_port: {{ .Values.depServices.redis.connectInfo.masterPort | quote }}
-      write_user: {{ .Values.depServices.redis.connectInfo.username | quote }}
-      write_password: {{ .Values.depServices.redis.connectInfo.password | quote }}
+      read_host: {{ $depServices.redis.connectInfo.slaveHost | quote }}
+      read_port: {{ $depServices.redis.connectInfo.slavePort | quote }}
+      read_user: {{ $depServices.redis.connectInfo.username | quote }}
+      read_password: {{ $depServices.redis.connectInfo.password | quote }}
+      write_host: {{ $depServices.redis.connectInfo.masterHost | quote }}
+      write_port: {{ $depServices.redis.connectInfo.masterPort | quote }}
+      write_user: {{ $depServices.redis.connectInfo.username | quote }}
+      write_password: {{ $depServices.redis.connectInfo.password | quote }}
       {{- end }}
 
     # 4. 图数据库相关
     graphdb:
-      host: {{ .Values.depServices.graphDatabase.host | quote }}
-      port: {{ .Values.depServices.graphDatabase.port | quote }}
-      type: {{ .Values.depServices.graphDatabase.type | quote }}
-      {{- if eq .Values.depServices.graphDatabase.type "nebulaGraph" }}
-      read_only_user: {{ .Values.depServices.graphDatabase.readonlyuser | quote }}
-      read_only_password: {{ .Values.depServices.graphDatabase.readonlypassword | quote }}
+      host: {{ $depServices.graphDatabase.host | quote }}
+      port: {{ $depServices.graphDatabase.port | quote }}
+      type: {{ $depServices.graphDatabase.type | quote }}
+      {{- if eq $depServices.graphDatabase.type "nebulaGraph" }}
+      read_only_user: {{ $depServices.graphDatabase.readonlyuser | quote }}
+      read_only_password: {{ $depServices.graphDatabase.readonlypassword | quote }}
       {{- end }}
 
     # 5. opensearch
     opensearch:
-      host: {{ .Values.depServices.opensearch.host | quote }}
-      port: {{ .Values.depServices.opensearch.port | quote }}
-      user: {{ .Values.depServices.opensearch.user | quote }}
-      password: {{ .Values.depServices.opensearch.password | quote }}
+      host: {{ $depServices.opensearch.host | quote }}
+      port: {{ $depServices.opensearch.port | quote }}
+      user: {{ $depServices.opensearch.user | quote }}
+      password: {{ $depServices.opensearch.password | quote }}
 
     # 6. 依赖的服务地址
     services:

--- a/agent-backend/deploy/helm/agent-backend/templates/configmap-factory.yaml
+++ b/agent-backend/deploy/helm/agent-backend/templates/configmap-factory.yaml
@@ -1,9 +1,10 @@
+{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
 apiVersion: v1
 data:
   dm_svc.conf: |
     TIME_ZON=(480)
     LANGUAGE=(cn)
-    DM={{ printf "(%s)" .Values.depServices.rds.host }}
+    DM={{ printf "(%s)" $depServices.rds.host }}
     [DM]
     LOGIN_MODE=(1)
 
@@ -15,7 +16,6 @@ data:
     switch_fields:
       keep_legacy_app_path: {{ .Values.service.keep_legacy_app_path | default false }}
       disable_pms_check: {{ .Values.service.disablePmsCheck | default false }}
-      disable_biz_domain: {{ .Values.service.disableBizDomain | default false }}
       disable_biz_domain_init: {{ .Values.service.disableBizDomainInit | default false }}
       use_default_biz_domain: {{ .Values.service.useDefaultBizDomain | default false }}
       disable_audit_init: {{ .Values.service.disableAuditInit | default false }}
@@ -42,96 +42,96 @@ data:
 
     hydra:
       user-mgnt:
-        host: {{ .Values.depServices.hydra.userMgnt.host }}
-        port: {{ .Values.depServices.hydra.userMgnt.port }}
+        host: {{ $depServices.hydra.userMgnt.host }}
+        port: {{ $depServices.hydra.userMgnt.port }}
       hydra-public:
-        host: {{ .Values.depServices.hydra.hydraPublic.host }}
-        port: {{ .Values.depServices.hydra.hydraPublic.port }}
+        host: {{ $depServices.hydra.hydraPublic.host }}
+        port: {{ $depServices.hydra.hydraPublic.port }}
       hydra-admin:
-        host: {{ .Values.depServices.hydra.hydraAdmin.host }}
-        port: {{ .Values.depServices.hydra.hydraAdmin.port }}
+        host: {{ $depServices.hydra.hydraAdmin.host }}
+        port: {{ $depServices.hydra.hydraAdmin.port }}
     model_factory:
       model_api_svc:
-        host: {{ .Values.depServices.modelFactory.modelApiSvc.host }}
-        port: {{ .Values.depServices.modelFactory.modelApiSvc.port }}
-        protocol: {{ .Values.depServices.modelFactory.modelApiSvc.protocol | quote }}
+        host: {{ $depServices.modelFactory.modelApiSvc.host }}
+        port: {{ $depServices.modelFactory.modelApiSvc.port }}
+        protocol: {{ $depServices.modelFactory.modelApiSvc.protocol | quote }}
       model_manager_svc:
-        host: {{ .Values.depServices.modelFactory.modelManagerSvc.host }}
-        port: {{ .Values.depServices.modelFactory.modelManagerSvc.port }}
-        protocol: {{ .Values.depServices.modelFactory.modelManagerSvc.protocol | quote }}
+        host: {{ $depServices.modelFactory.modelManagerSvc.host }}
+        port: {{ $depServices.modelFactory.modelManagerSvc.port }}
+        protocol: {{ $depServices.modelFactory.modelManagerSvc.protocol | quote }}
     authorization:
       public_svc:
-        host: {{ .Values.depServices.authorization.publicSvc.host | quote }}
-        port: {{ .Values.depServices.authorization.publicSvc.port }}
-        protocol: {{ .Values.depServices.authorization.publicSvc.protocol | quote }}
+        host: {{ $depServices.authorization.publicSvc.host | quote }}
+        port: {{ $depServices.authorization.publicSvc.port }}
+        protocol: {{ $depServices.authorization.publicSvc.protocol | quote }}
       private_svc:
-        host: {{ .Values.depServices.authorization.privateSvc.host | quote }}
-        port: {{ .Values.depServices.authorization.privateSvc.port }}
-        protocol: {{ .Values.depServices.authorization.privateSvc.protocol | quote }}
+        host: {{ $depServices.authorization.privateSvc.host | quote }}
+        port: {{ $depServices.authorization.privateSvc.port }}
+        protocol: {{ $depServices.authorization.privateSvc.protocol | quote }}
     # ========== Sandbox Platform 配置 ==========
     sandbox_platform:
-      enable: {{ .Values.depServices.sandboxPlatform.enable | default true }}
+      enable: {{ $depServices.sandboxPlatform.enable | default true }}
       public_svc:
-        host: {{ .Values.depServices.sandboxPlatform.publicSvc.host | quote }}
-        port: {{ .Values.depServices.sandboxPlatform.publicSvc.port }}
-        protocol: {{ .Values.depServices.sandboxPlatform.publicSvc.protocol | quote }}
+        host: {{ $depServices.sandboxPlatform.publicSvc.host | quote }}
+        port: {{ $depServices.sandboxPlatform.publicSvc.port }}
+        protocol: {{ $depServices.sandboxPlatform.publicSvc.protocol | quote }}
       private_svc:
-        host: {{ .Values.depServices.sandboxPlatform.privateSvc.host | quote }}
-        port: {{ .Values.depServices.sandboxPlatform.privateSvc.port }}
-        protocol: {{ .Values.depServices.sandboxPlatform.privateSvc.protocol | quote }}
-      default_ttl: {{ .Values.depServices.sandboxPlatform.defaultTtl | default 3600 }}
-      max_retries: {{ .Values.depServices.sandboxPlatform.maxRetries | default 10 }}
-      retry_interval: {{ .Values.depServices.sandboxPlatform.retryInterval | quote | default "500ms" }}
-      default_template_id: {{ .Values.depServices.sandboxPlatform.defaultTemplateId | quote | default "python-basic" }}
-      default_cpu: {{ .Values.depServices.sandboxPlatform.defaultCpu | quote | default "1" }}
-      default_memory: {{ .Values.depServices.sandboxPlatform.defaultMemory | quote | default "512Mi" }}
-      default_disk: {{ .Values.depServices.sandboxPlatform.defaultDisk | quote | default "1Gi" }}
-      default_timeout: {{ .Values.depServices.sandboxPlatform.defaultTimeout | default 300 }}
+        host: {{ $depServices.sandboxPlatform.privateSvc.host | quote }}
+        port: {{ $depServices.sandboxPlatform.privateSvc.port }}
+        protocol: {{ $depServices.sandboxPlatform.privateSvc.protocol | quote }}
+      default_ttl: {{ $depServices.sandboxPlatform.defaultTtl | default 3600 }}
+      max_retries: {{ $depServices.sandboxPlatform.maxRetries | default 10 }}
+      retry_interval: {{ $depServices.sandboxPlatform.retryInterval | quote | default "500ms" }}
+      default_template_id: {{ $depServices.sandboxPlatform.defaultTemplateId | quote | default "python-basic" }}
+      default_cpu: {{ $depServices.sandboxPlatform.defaultCpu | quote | default "1" }}
+      default_memory: {{ $depServices.sandboxPlatform.defaultMemory | quote | default "512Mi" }}
+      default_disk: {{ $depServices.sandboxPlatform.defaultDisk | quote | default "1Gi" }}
+      default_timeout: {{ $depServices.sandboxPlatform.defaultTimeout | default 300 }}
       file_upload_config:
-        max_file_size: {{ .Values.depServices.sandboxPlatform.fileUploadConfig.maxFileSize | default 10 }}
-        max_file_size_unit: {{ .Values.depServices.sandboxPlatform.fileUploadConfig.maxFileSizeUnit | quote | default "MB" }}
-        max_file_count: {{ .Values.depServices.sandboxPlatform.fileUploadConfig.maxFileCount | default 10 }}
+        max_file_size: {{ $depServices.sandboxPlatform.fileUploadConfig.maxFileSize | default 10 }}
+        max_file_size_unit: {{ $depServices.sandboxPlatform.fileUploadConfig.maxFileSizeUnit | quote | default "MB" }}
+        max_file_count: {{ $depServices.sandboxPlatform.fileUploadConfig.maxFileCount | default 10 }}
         allowed_file_types:
-        {{- toYaml .Values.depServices.sandboxPlatform.fileUploadConfig.allowedFileTypes | nindent 8 }}
+        {{- toYaml $depServices.sandboxPlatform.fileUploadConfig.allowedFileTypes | nindent 8 }}
     # ========================================
 
     agent_factory:
       private_svc:
-        host: {{ .Values.depServices.agentFactory.privateSvc.host | quote }}
-        port: {{ .Values.depServices.agentFactory.privateSvc.port }}
-        protocol: {{ .Values.depServices.agentFactory.privateSvc.protocol | quote }}
+        host: {{ $depServices.agentFactory.privateSvc.host | quote }}
+        port: {{ $depServices.agentFactory.privateSvc.port }}
+        protocol: {{ $depServices.agentFactory.privateSvc.protocol | quote }}
     # ========== Agent Executor 配置 ==========
     agent_executor:
       private_svc:
-        host: {{ .Values.depServices.agentExecutor.privateSvc.host | quote }}
-        port: {{ .Values.depServices.agentExecutor.privateSvc.port }}
-        protocol: {{ .Values.depServices.agentExecutor.privateSvc.protocol | quote }}
+        host: {{ $depServices.agentExecutor.privateSvc.host | quote }}
+        port: {{ $depServices.agentExecutor.privateSvc.port }}
+        protocol: {{ $depServices.agentExecutor.privateSvc.protocol | quote }}
     # ========================================
     uniquery:
       public_svc:
-        host: {{ .Values.depServices.uniquery.publicSvc.host | quote }}
-        port: {{ .Values.depServices.uniquery.publicSvc.port }}
-        protocol: {{ .Values.depServices.uniquery.publicSvc.protocol | quote }}
+        host: {{ $depServices.uniquery.publicSvc.host | quote }}
+        port: {{ $depServices.uniquery.publicSvc.port }}
+        protocol: {{ $depServices.uniquery.publicSvc.protocol | quote }}
       private_svc:
-        host: {{ .Values.depServices.uniquery.privateSvc.host | quote }}
-        port: {{ .Values.depServices.uniquery.privateSvc.port }}
-        protocol: {{ .Values.depServices.uniquery.privateSvc.protocol | quote }}
+        host: {{ $depServices.uniquery.privateSvc.host | quote }}
+        port: {{ $depServices.uniquery.privateSvc.port }}
+        protocol: {{ $depServices.uniquery.privateSvc.protocol | quote }}
     # ========================================
     biz_domain:
       public_svc:
-        host: {{ .Values.depServices.bizDomain.publicSvc.host | quote }}
-        port: {{ .Values.depServices.bizDomain.publicSvc.port }}
-        protocol: {{ .Values.depServices.bizDomain.publicSvc.protocol | quote }}
+        host: {{ $depServices.bizDomain.publicSvc.host | quote }}
+        port: {{ $depServices.bizDomain.publicSvc.port }}
+        protocol: {{ $depServices.bizDomain.publicSvc.protocol | quote }}
       private_svc:
-        host: {{ .Values.depServices.bizDomain.privateSvc.host | quote }}
-        port: {{ .Values.depServices.bizDomain.privateSvc.port }}
-        protocol: {{ .Values.depServices.bizDomain.privateSvc.protocol | quote }}
+        host: {{ $depServices.bizDomain.privateSvc.host | quote }}
+        port: {{ $depServices.bizDomain.privateSvc.port }}
+        protocol: {{ $depServices.bizDomain.privateSvc.protocol | quote }}
     opentelemetry:
       {{- toYaml .Values.opentelemetry | nindent 6 }}
   mq_config.yaml: |
-    {{- toYaml .Values.depServices.mq | nindent 4 }}
+    {{- toYaml $depServices.mq | nindent 4 }}
 
 kind: ConfigMap
 metadata:
-  name: agent-factory-yaml
-  namespace: {{ .Values.namespace }}
+  name: agent-backend-factory-yaml
+  namespace: {{ .Release.Namespace }}

--- a/agent-backend/deploy/helm/agent-backend/templates/configmap-memory.yaml
+++ b/agent-backend/deploy/helm/agent-backend/templates/configmap-memory.yaml
@@ -1,34 +1,39 @@
 # Agent Memory ConfigMap (环境变量)
 # 从老Chart复制，修改name为固定值
+{{ $depServices := include "mergedGlobalValues.depServices" . | fromYaml }}
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-backend-memory-yaml
+  namespace: {{ .Release.Namespace }}
 data:
-  RDSHOST: {{ .Values.depServices.rds.host | quote}}
-  RDSPORT: {{ quote .Values.depServices.rds.port }}
-  RDSUSER: {{ .Values.depServices.rds.user | quote}}
-  RDSPASS: {{ .Values.depServices.rds.password | quote}}
-  DB_TYPE: {{ .Values.depServices.rds.type | quote}}
-  RDSDBNAME: {{ .Values.depServices.rds.database | quote}}
-  REDISCLUSTERMODE: {{ .Values.depServices.redis.connectType | quote}}
-  REDISUSER: {{ .Values.depServices.redis.connectInfo.username | quote}}
-  REDISPASS: {{ .Values.depServices.redis.connectInfo.password | quote}}
-  {{- if eq .Values.depServices.redis.connectType "sentinel" }}
-  REDISHOST: {{ quote .Values.depServices.redis.connectInfo.sentinelHost }}
-  REDISPORT: {{ quote .Values.depServices.redis.connectInfo.sentinelPort }}
-  SENTINELMASTER: {{ .Values.depServices.redis.connectInfo.masterGroupName | quote }}
-  SENTINELUSER: {{ .Values.depServices.redis.connectInfo.sentinelUsername | quote}}
-  SENTINELPASS: {{ .Values.depServices.redis.connectInfo.sentinelPassword | quote}}
-  {{- else if eq .Values.depServices.redis.connectType "standalone" }}
-  REDISHOST: {{ quote .Values.depServices.redis.connectInfo.host }}
-  REDISPORT: {{ quote .Values.depServices.redis.connectInfo.port }}
-  {{- else if eq .Values.depServices.redis.connectType "master-slave" }}
-  REDISREADHOST: {{ .Values.depServices.redis.connectInfo.slaveHost | quote}}
-  REDISREADPORT: {{ quote .Values.depServices.redis.connectInfo.slavePort }}
-  REDISREADUSER: {{ .Values.depServices.redis.connectInfo.username | quote}}
-  REDISREADPASS: {{ .Values.depServices.redis.connectInfo.password | quote}}
-  REDISWRITEHOST: {{ .Values.depServices.redis.connectInfo.masterHost | quote}}
-  REDISWRITEPORT: {{ quote .Values.depServices.redis.connectInfo.masterPort }}
-  REDISWRITEUSER: {{ .Values.depServices.redis.connectInfo.username | quote}}
-  REDISWRITEPASS: {{ .Values.depServices.redis.connectInfo.password | quote}}
+  RDSHOST: {{ $depServices.rds.host | quote}}
+  RDSPORT: {{ quote $depServices.rds.port }}
+  RDSUSER: {{ $depServices.rds.user | quote}}
+  RDSPASS: {{ $depServices.rds.password | quote}}
+  DB_TYPE: {{ $depServices.rds.type | quote}}
+  RDSDBNAME: {{ $depServices.rds.database | quote}}
+  REDISCLUSTERMODE: {{ $depServices.redis.connectType | quote}}
+  REDISUSER: {{ $depServices.redis.connectInfo.username | quote}}
+  REDISPASS: {{ $depServices.redis.connectInfo.password | quote}}
+  {{- if eq $depServices.redis.connectType "sentinel" }}
+  REDISHOST: {{ quote $depServices.redis.connectInfo.sentinelHost }}
+  REDISPORT: {{ quote $depServices.redis.connectInfo.sentinelPort }}
+  SENTINELMASTER: {{ $depServices.redis.connectInfo.masterGroupName | quote }}
+  SENTINELUSER: {{ $depServices.redis.connectInfo.sentinelUsername | quote}}
+  SENTINELPASS: {{ $depServices.redis.connectInfo.sentinelPassword | quote}}
+  {{- else if eq $depServices.redis.connectType "standalone" }}
+  REDISHOST: {{ quote $depServices.redis.connectInfo.host }}
+  REDISPORT: {{ quote $depServices.redis.connectInfo.port }}
+  {{- else if eq $depServices.redis.connectType "master-slave" }}
+  REDISREADHOST: {{ $depServices.redis.connectInfo.slaveHost | quote}}
+  REDISREADPORT: {{ quote $depServices.redis.connectInfo.slavePort }}
+  REDISREADUSER: {{ $depServices.redis.connectInfo.username | quote}}
+  REDISREADPASS: {{ $depServices.redis.connectInfo.password | quote}}
+  REDISWRITEHOST: {{ $depServices.redis.connectInfo.masterHost | quote}}
+  REDISWRITEPORT: {{ quote $depServices.redis.connectInfo.masterPort }}
+  REDISWRITEUSER: {{ $depServices.redis.connectInfo.username | quote}}
+  REDISWRITEPASS: {{ $depServices.redis.connectInfo.password | quote}}
   {{- end }}
   DUAL_STACK: {{ quote .Values.service.enableDualStack }}
   LOG_URL: {{ .Values.agentMemory.telemetry.log.endpoint | quote }}
@@ -37,25 +42,25 @@ data:
   METRIC_ENABLE: {{ quote .Values.agentMemory.telemetry.metric.enabled }}
   TRACE_ENABLE: {{ quote .Values.agentMemory.telemetry.trace.enabled }}
   TRACE_URL: {{ .Values.agentMemory.telemetry.trace.endpoint | quote}}
-  OPENSEARCH_HOST: {{ .Values.depServices.opensearch.host | quote}}
-  OPENSEARCHRED: {{ .Values.depServices.opensearch.read | quote}}
-  OPENSEARCHWRITE: {{ .Values.depServices.opensearch.write | quote}}
-  OPENSEARCH_PORT: {{ quote .Values.depServices.opensearch.port }}
-  OPENSEARCH_USER: {{ .Values.depServices.opensearch.user | quote}}
-  OPENSEARCH_PASS: {{ .Values.depServices.opensearch.password | quote}}
-  GRAPHDB_TYPE: {{ quote .Values.depServices.graphDatabase.type }}
-  GRAPHDB_HOST: {{ quote .Values.depServices.graphDatabase.host }}
-  GRAPHDB_PORT: {{ quote .Values.depServices.graphDatabase.port }}
-  GRAPHDB_USER: {{ quote .Values.depServices.graphDatabase.user }}
-  GRAPHDB_PASSWORD: {{ quote .Values.depServices.graphDatabase.password }}
-  {{- if eq .Values.depServices.graphDatabase.type "nebulaGraph" }}
-  GRAPHDB_READ_ONLY_USER: {{ quote .Values.depServices.graphDatabase.readonlyuser }}
-  GRAPHDB_READ_ONLY_PASSWORD: {{ quote .Values.depServices.graphDatabase.readonlypassword }}
+  OPENSEARCH_HOST: {{ $depServices.opensearch.host | quote}}
+  OPENSEARCHRED: {{ $depServices.opensearch.read | quote}}
+  OPENSEARCHWRITE: {{ $depServices.opensearch.write | quote}}
+  OPENSEARCH_PORT: {{ quote $depServices.opensearch.port }}
+  OPENSEARCH_USER: {{ $depServices.opensearch.user | quote}}
+  OPENSEARCH_PASS: {{ $depServices.opensearch.password | quote}}
+  GRAPHDB_TYPE: {{ quote $depServices.graphDatabase.type }}
+  GRAPHDB_HOST: {{ quote $depServices.graphDatabase.host }}
+  GRAPHDB_PORT: {{ quote $depServices.graphDatabase.port }}
+  GRAPHDB_USER: {{ quote $depServices.graphDatabase.user }}
+  GRAPHDB_PASSWORD: {{ quote $depServices.graphDatabase.password }}
+  {{- if eq $depServices.graphDatabase.type "nebulaGraph" }}
+  GRAPHDB_READ_ONLY_USER: {{ quote $depServices.graphDatabase.readonlyuser }}
+  GRAPHDB_READ_ONLY_PASSWORD: {{ quote $depServices.graphDatabase.readonlypassword }}
   {{- end }}
   # Memory特有变量
   EMBEDDING_MODEL: {{ quote .Values.agentMemory.embedding.model }}
-  EMB_URL:  {{ quote .Values.depServices.llm_ad.embeddingUrl }}
-  EMBEDDING_DIMENSION: {{ quote .Values.depServices.llm_ad.embeddingDimension }}
+  EMB_URL:  {{ quote $depServices.llm_ad.embeddingUrl }}
+  EMBEDDING_DIMENSION: {{ quote $depServices.llm_ad.embeddingDimension }}
   LLM_BASE_URL: {{ quote .Values.agentMemory.llm.base_url }}
   LLM_MODEL: {{ quote .Values.agentMemory.llm.model }}
   EMBEDDING_MODEL_BASE_URL: {{ quote .Values.agentMemory.embedding.base_url }}
@@ -65,10 +70,6 @@ data:
   dm_svc.conf: |
     TIME_ZON=(480)
     LANGUAGE=(cn)
-    DM={{ printf "(%s)" .Values.depServices.rds.host }}
+    DM={{ printf "(%s)" $depServices.rds.host }}
     [DM]
     LOGIN_MODE=(1)
-kind: ConfigMap
-metadata:
-  name: agent-memory-yaml
-  namespace: {{ .Values.namespace }}

--- a/agent-backend/deploy/helm/agent-backend/templates/deployment.yaml
+++ b/agent-backend/deploy/helm/agent-backend/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- $env := include "mergedGlobalValues.env" . | fromYaml -}}
+{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
+{{- $imageRegistry := include "mergedGlobalValues.imageRegistry" . -}}
 {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: apps/v1
 {{- else -}}
@@ -5,13 +8,13 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Deployment
 metadata:
-  name: agent-factory
-  namespace: {{ .Values.namespace }}
+  name: agent-backend-factory
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
-      app: agent-factory
-  replicas: {{ .Values.replicaCount }}
+      app: agent-backend-factory
+  replicas: {{ include "mergedGlobalValues.replicaCount" . }}
   strategy:
     rollingUpdate:
       maxSurge: 0
@@ -22,7 +25,7 @@ spec:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap-factory.yaml") . | sha256sum }}
       labels:
-        app: agent-factory
+        app: agent-backend-factory
     spec:
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -36,7 +39,7 @@ spec:
               - key: app
                 operator: In
                 values:
-                - agent-factory
+                - agent-backend-factory
             topologyKey: "kubernetes.io/hostname"
       {{- if ne .Values.runMode "dev" }}
       {{- if eq .Values.enableSecurityContext true }}
@@ -47,9 +50,9 @@ spec:
       {{- end }}
       {{- end }}
       containers:
-        - name: agent-factory
+        - name: agent-backend-factory
           {{- if ne .Values.runMode "dev" }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.service.repository }}:{{ .Values.image.service.tag }}"
+          image: "{{ $imageRegistry }}/{{ .Values.image.service.repository }}:{{ .Values.image.service.tag }}"
           imagePullPolicy: {{ .Values.image.service.pullPolicy }}
           {{- else}}
           image: "acr.aishu.cn/client/godevenv:1.16.2"
@@ -57,24 +60,24 @@ spec:
 
           env:
               - name: AGENT_FACTORY_DISABLE_PMS_CHECK
-                value: {{ .Values.env.disable_pms_check | quote }}
+                value: {{ $env.disable_pms_check | quote }}
               - name: SERVICE_NAME
-                value: agent-factory
+                value: agent-backend-factory
               - name: DB_TYPE
-                value: {{ .Values.depServices.rds.type | quote }}
+                value: {{ $depServices.rds.type | quote }}
             {{- if .Values.service.loggerOutput}}
               - name: LOGOUT
                 value: {{ .Values.service.loggerOutput }}
             {{- end}}
-            {{- if .Values.env.language}}
+            {{- if $env.language}}
               - name: LANG
-                value: {{ .Values.env.language }}
+                value: {{ $env.language }}
               - name: LC_ALL
-                value: {{ .Values.env.language }}
+                value: {{ $env.language }}
             {{- end}}
-            {{- if .Values.env.timezone}}
+            {{- if $env.timezone}}
               - name: TZ
-                value: {{ .Values.env.timezone }}
+                value: {{ $env.timezone }}
             {{- end}}
 
               # ========== Memory特有环境变量 (从agent-memory-yaml ConfigMap获取) ==========
@@ -86,139 +89,139 @@ spec:
                 valueFrom:
                   configMapKeyRef:
                     key: RDSHOST
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: RDSPORT
                 valueFrom:
                   configMapKeyRef:
                     key: RDSPORT
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: RDSUSER
                 valueFrom:
                   configMapKeyRef:
                     key: RDSUSER
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: RDSPASS
                 valueFrom:
                   configMapKeyRef:
                     key: RDSPASS
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: RDSDBNAME
                 valueFrom:
                   configMapKeyRef:
                     key: RDSDBNAME
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: TRACE_URL
                 valueFrom:
                   configMapKeyRef:
                     key: TRACE_URL
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: TRACE_ENABLE
                 valueFrom:
                   configMapKeyRef:
                     key: TRACE_ENABLE
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: GRAPHDB_TYPE
                 valueFrom:
                   configMapKeyRef:
                     key: GRAPHDB_TYPE
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: GRAPHDB_HOST
                 valueFrom:
                   configMapKeyRef:
                     key: GRAPHDB_HOST
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: GRAPHDB_PORT
                 valueFrom:
                   configMapKeyRef:
                     key: GRAPHDB_PORT
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: GRAPHDB_USER
                 valueFrom:
                   configMapKeyRef:
                     key: GRAPHDB_USER
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: GRAPHDB_PASSWORD
                 valueFrom:
                   configMapKeyRef:
                     key: GRAPHDB_PASSWORD
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: OPENSEARCH_HOST
                 valueFrom:
                   configMapKeyRef:
                     key: OPENSEARCH_HOST
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: OPENSEARCH_PORT
                 valueFrom:
                   configMapKeyRef:
                     key: OPENSEARCH_PORT
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: OPENSEARCH_USER
                 valueFrom:
                   configMapKeyRef:
                     key: OPENSEARCH_USER
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: OPENSEARCH_PASS
                 valueFrom:
                   configMapKeyRef:
                     key: OPENSEARCH_PASS
-                    name: agent-memory-yaml
-              {{- if eq .Values.depServices.graphDatabase.type "nebulaGraph" }}
+                    name: agent-backend-memory-yaml
+              {{- if eq $depServices.graphDatabase.type "nebulaGraph" }}
               - name: GRAPHDB_READ_ONLY_USER
                 valueFrom:
                   configMapKeyRef:
                     key: GRAPHDB_READ_ONLY_USER
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: GRAPHDB_READ_ONLY_PASSWORD
                 valueFrom:
                   configMapKeyRef:
                     key: GRAPHDB_READ_ONLY_PASSWORD
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               {{- end }}
               - name: EMBEDDING_MODEL
                 valueFrom:
                   configMapKeyRef:
                     key: EMBEDDING_MODEL
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: EMB_URL
                 valueFrom:
                   configMapKeyRef:
                     key: EMB_URL
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: EMBEDDING_DIMENSION
                 valueFrom:
                   configMapKeyRef:
                     key: EMBEDDING_DIMENSION
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: LLM_BASE_URL
                 valueFrom:
                   configMapKeyRef:
                     key: LLM_BASE_URL
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: LLM_MODEL
                 valueFrom:
                   configMapKeyRef:
                     key: LLM_MODEL
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: EMBEDDING_MODEL_BASE_URL
                 valueFrom:
                   configMapKeyRef:
                     key: EMBEDDING_MODEL_BASE_URL
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: EMBEDDING_MODEL_DIMS
                 valueFrom:
                   configMapKeyRef:
                     key: EMBEDDING_MODEL_DIMS
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: RERANK_MODEL
                 valueFrom:
                   configMapKeyRef:
                     key: RERANK_MODEL
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               - name: RERANK_URL
                 valueFrom:
                   configMapKeyRef:
                     key: RERANK_URL
-                    name: agent-memory-yaml
+                    name: agent-backend-memory-yaml
               # ========== Memory环境变量结束 ==========
 
               - name: DM_SVC_PATH
@@ -254,17 +257,17 @@ spec:
           {{- end}}
           volumeMounts:
             # ========== ConfigMap文件使用subPath精确挂载 ==========
-            - name: agent-factory-yaml
+            - name: agent-backend-factory-yaml
               mountPath: /sysvol/conf/agent-factory.yaml
               subPath: agent-factory.yaml
-            - name: agent-factory-yaml
+            - name: agent-backend-factory-yaml
               mountPath: /sysvol/conf/dm_svc.conf
               subPath: dm_svc.conf
-            - name: agent-factory-yaml
+            - name: agent-backend-factory-yaml
               mountPath: /sysvol/conf/mq_config.yaml
               subPath: mq_config.yaml
             # ========== Secret使用目录级挂载 ==========
-            - name: agent-factory-secret-yaml
+            - name: agent-backend-factory-secret-yaml
               mountPath: /sysvol/conf/secret
             # ========== Executor配置文件挂载 ==========
             - name: executor-yaml
@@ -290,16 +293,16 @@ spec:
               memory: {{ .Values.resources.limits.memory }}
           {{ end }}
       volumes:
-        - name: agent-factory-yaml
+        - name: agent-backend-factory-yaml
           configMap:
-            name: agent-factory-yaml
-        - name: agent-factory-secret-yaml
+            name: agent-backend-factory-yaml
+        - name: agent-backend-factory-secret-yaml
           secret:
             secretName: agent-factory-secret-yaml
         # ========== Executor配置Volume ==========
         - name: executor-yaml
           configMap:
-            name: agent-executor-yaml
+            name: agent-backend-executor-yaml
         # ========== 时间同步Volume ==========
         - name: host-time
           hostPath:
@@ -307,7 +310,7 @@ spec:
         # ========== DM配置Volume ==========
         - name: rds-conf
           configMap:
-            name: agent-factory-yaml
+            name: agent-backend-factory-yaml
             items:
             - key: dm_svc.conf
               path: dm_svc.conf

--- a/agent-backend/deploy/helm/agent-backend/templates/ingress.yaml
+++ b/agent-backend/deploy/helm/agent-backend/templates/ingress.yaml
@@ -1,15 +1,16 @@
 {{- if .Values.service.agentFactory.ingress.enabled -}}
 {{ if .Values.service.agentFactory.ingress.interface }}
+{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: agent-factory-ingress
-  namespace: {{ .Values.namespace }}
+  name: agent-backend-factory-ingress
+  namespace: {{ .Release.Namespace }}
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "500M"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
-  ingressClassName: {{ index .Values.depServices "class-443" "ingressClass" }}
+  ingressClassName: {{ index $depServices "class-443" "ingressClass" }}
   rules:
   - http:
       paths:
@@ -18,7 +19,7 @@ spec:
           pathType: ImplementationSpecific
           backend:
             service:
-              name: agent-factory
+              name: agent-backend-factory
               port:
                 number: {{ $.Values.service.agentFactory.port }}
         {{- end }}

--- a/agent-backend/deploy/helm/agent-backend/templates/secret.yaml
+++ b/agent-backend/deploy/helm/agent-backend/templates/secret.yaml
@@ -1,50 +1,52 @@
+{{- $env := include "mergedGlobalValues.env" . | fromYaml -}}
+{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: agent-factory-secret-yaml
-  namespace: {{ .Values.namespace }}
+  name: agent-backend-factory-secret-yaml
+  namespace: {{ .Release.Namespace }}
 stringData:
   # 配置文件路径/sysvol/conf/secret/agent-factory-secret.yaml
   agent-factory-secret.yaml: |
     db:
-      user_name: {{ .Values.depServices.rds.user }}
-      user_pwd: {{ .Values.depServices.rds.password | quote }}
-      db_host: {{ .Values.depServices.rds.host }}
-      db_port: {{ .Values.depServices.rds.port }}
-      db_host_read: {{ .Values.depServices.rds.hostRead }}
-      db_port_read: {{ .Values.depServices.rds.portRead }}
-      db_name: {{ .Values.depServices.rds.database }}
-      db_charset: {{ .Values.depServices.rds.dbCharset }}
-      timeout: {{ .Values.depServices.rds.timeout }}
-      read_timeout: {{ .Values.depServices.rds.readTimeout }}
-      write_timeout: {{ .Values.depServices.rds.writeTimeout }}
-      max_open_conns: {{ .Values.depServices.rds.maxConnections }}
-      max_open_read_conns: {{ .Values.depServices.rds.maxReadConnections }}
+      user_name: {{ $depServices.rds.user }}
+      user_pwd: {{ $depServices.rds.password | quote }}
+      db_host: {{ $depServices.rds.host }}
+      db_port: {{ $depServices.rds.port }}
+      db_host_read: {{ $depServices.rds.hostRead }}
+      db_port_read: {{ $depServices.rds.portRead }}
+      db_name: {{ $depServices.rds.database }}
+      db_charset: {{ $depServices.rds.dbCharset }}
+      timeout: {{ $depServices.rds.timeout }}
+      read_timeout: {{ $depServices.rds.readTimeout }}
+      write_timeout: {{ $depServices.rds.writeTimeout }}
+      max_open_conns: {{ $depServices.rds.maxConnections }}
+      max_open_read_conns: {{ $depServices.rds.maxReadConnections }}
       max_idle_conns: 10
       conn_max_lifetime: 500
     redis:
-      connect_type: {{ .Values.depServices.redis.connectType | quote }}
-      password: {{ .Values.depServices.redis.connectInfo.password | quote }}
-      username: {{ .Values.depServices.redis.connectInfo.username | quote }}
-      db: {{ .Values.depServices.redis.db }}
+      connect_type: {{ $depServices.redis.connectType | quote }}
+      password: {{ $depServices.redis.connectInfo.password | quote }}
+      username: {{ $depServices.redis.connectInfo.username | quote }}
+      db: {{ $depServices.redis.db }}
 
       # standalone 单机模式
-      host: {{ .Values.depServices.redis.connectInfo.host | quote }}
-      port: {{ .Values.depServices.redis.connectInfo.port | quote }}
+      host: {{ $depServices.redis.connectInfo.host | quote }}
+      port: {{ $depServices.redis.connectInfo.port | quote }}
 
       # sentinel 模式配置
-      master_group_name: {{ .Values.depServices.redis.connectInfo.masterGroupName | quote }}
-      sentinel_host: {{ .Values.depServices.redis.connectInfo.sentinelHost | quote }}
-      sentinel_port: {{ .Values.depServices.redis.connectInfo.sentinelPort | quote }}
-      sentinel_username: {{ .Values.depServices.redis.connectInfo.sentinelUsername | quote }}
-      sentinel_password: {{ .Values.depServices.redis.connectInfo.sentinelPassword | quote }}
+      master_group_name: {{ $depServices.redis.connectInfo.masterGroupName | quote }}
+      sentinel_host: {{ $depServices.redis.connectInfo.sentinelHost | quote }}
+      sentinel_port: {{ $depServices.redis.connectInfo.sentinelPort | quote }}
+      sentinel_username: {{ $depServices.redis.connectInfo.sentinelUsername | quote }}
+      sentinel_password: {{ $depServices.redis.connectInfo.sentinelPassword | quote }}
 
       # master-slave 主从模式
-      master_host: {{ .Values.depServices.redis.connectInfo.masterHost | quote }}
-      master_port: {{ .Values.depServices.redis.connectInfo.masterPort | quote }}
-      slave_host: {{ .Values.depServices.redis.connectInfo.slaveHost | quote }}
-      slave_port: {{ .Values.depServices.redis.connectInfo.slavePort | quote }}
+      master_host: {{ $depServices.redis.connectInfo.masterHost | quote }}
+      master_port: {{ $depServices.redis.connectInfo.masterPort | quote }}
+      slave_host: {{ $depServices.redis.connectInfo.slaveHost | quote }}
+      slave_port: {{ $depServices.redis.connectInfo.slavePort | quote }}
 
     model_factory:
       llm:
-        api_key: {{ .Values.depServices.modelFactory.llm.apiKey | quote }}
+        api_key: {{ $depServices.modelFactory.llm.apiKey | quote }}

--- a/agent-backend/deploy/helm/agent-backend/templates/service-app.yaml
+++ b/agent-backend/deploy/helm/agent-backend/templates/service-app.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: agent-app
-  namespace: {{ .Values.namespace }}
+  name: agent-backend-app
+  namespace: {{ .Release.Namespace }}
   labels:
-    app: agent-app
+    app: agent-backend-app
 spec:
   {{- if .Values.service.enableDualStack }}
   ipFamilies:
@@ -21,7 +21,7 @@ spec:
       nodePort: {{ .Values.service.agentApp.nodePort }}
       {{- end}}
   selector:
-    app: agent-factory
+    app: agent-backend-factory
   type: {{ .Values.service.type }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}
   sessionAffinityConfig:

--- a/agent-backend/deploy/helm/agent-backend/templates/service-executor.yaml
+++ b/agent-backend/deploy/helm/agent-backend/templates/service-executor.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: agent-executor
-  namespace: {{ .Values.namespace }}
+  name: agent-backend-executor
+  namespace: {{ .Release.Namespace }}
   labels:
-    app: agent-factory
-    service: agent-executor
+    app: agent-backend-factory
+    service: agent-backend-executor
 spec:
   ports:
     - name: executor-port
@@ -14,5 +14,5 @@ spec:
       port: {{ .Values.agentExecutor.port }}
       targetPort: {{ .Values.agentExecutor.port }}
   selector:
-    app: agent-factory
+    app: agent-backend-factory
   type: ClusterIP

--- a/agent-backend/deploy/helm/agent-backend/templates/service-factory.yaml
+++ b/agent-backend/deploy/helm/agent-backend/templates/service-factory.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: agent-factory
-  namespace: {{ .Values.namespace }}
+  name: agent-backend-factory
+  namespace: {{ .Release.Namespace }}
   labels:
-    app: agent-factory
+    app: agent-backend-factory
 spec:
   {{- if .Values.service.enableDualStack }}
   ipFamilies:
@@ -21,5 +21,5 @@ spec:
       nodePort: {{ .Values.service.port }}
       {{- end}}
   selector:
-    app: agent-factory
+    app: agent-backend-factory
   type: {{ .Values.service.type }}

--- a/agent-backend/deploy/helm/agent-backend/templates/service-memory.yaml
+++ b/agent-backend/deploy/helm/agent-backend/templates/service-memory.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: agent-memory
-  namespace: {{ .Values.namespace }}
+  name: agent-backend-memory
+  namespace: {{ .Release.Namespace }}
   labels:
-    app: agent-factory
-    service: agent-memory
+    app: agent-backend-factory
+    service: agent-backend-memory
 spec:
   ports:
     - name: memory-port
@@ -14,5 +14,5 @@ spec:
       port: {{ .Values.agentMemory.port }}
       targetPort: {{ .Values.agentMemory.port }}
   selector:
-    app: agent-factory
+    app: agent-backend-factory
   type: ClusterIP

--- a/agent-web/charts/agent-web/templates/_helpers.tpl
+++ b/agent-web/charts/agent-web/templates/_helpers.tpl
@@ -1,0 +1,105 @@
+{{/* vim: set filetype=mustache: */}}
+
+
+{{/* ========== Universal Global Values Merge Helpers ========== */}}
+{{/* All charts use these same helper function names for consistency */}}
+
+{{- define "mergedGlobalValues.imageRegistry" -}}
+{{- $globalImage := (.Values.global | default dict).image | default dict -}}
+{{- if $globalImage.registry -}}
+{{- $globalImage.registry -}}
+{{- else -}}
+{{- .Values.image.registry -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.replicaCount" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "replicaCount" -}}
+{{- $global.replicaCount -}}
+{{- else -}}
+{{- .Values.replicaCount -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.env" -}}
+{{- $globalEnv := (.Values.global | default dict).env | default dict -}}
+{{- if $globalEnv -}}
+{{- toYaml (mergeOverwrite (deepCopy (.Values.env | default dict)) $globalEnv) -}}
+{{- else -}}
+{{- toYaml .Values.env -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.depServices" -}}
+{{- $globalDeps := (.Values.global | default dict).depServices | default dict -}}
+{{- if $globalDeps -}}
+{{- toYaml (mergeOverwrite (deepCopy (.Values.depServices | default dict)) $globalDeps) -}}
+{{- else -}}
+{{- toYaml .Values.depServices -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.imagePullSecrets" -}}
+{{- $localSecrets := .Values.imagePullSecrets | default (list) -}}
+{{- $globalSecrets := (.Values.global | default dict).imagePullSecrets | default (list) -}}
+{{- if gt (len $localSecrets) 0 -}}
+{{- toYaml $localSecrets -}}
+{{- else if gt (len $globalSecrets) 0 -}}
+{{- toYaml $globalSecrets -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.namespace" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "namespace" -}}
+{{- $global.namespace -}}
+{{- else -}}
+{{- .Values.namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.mode" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "mode" -}}
+{{- $global.mode -}}
+{{- else -}}
+{{- .Values.mode | default "Community" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.accessAddress" -}}
+{{- $globalAccess := (.Values.global | default dict).accessAddress | default dict -}}
+{{- if $globalAccess -}}
+{{- toYaml (mergeOverwrite (deepCopy (.Values.accessAddress | default dict)) $globalAccess) -}}
+{{- else -}}
+{{- toYaml .Values.accessAddress -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.ingressClassName" -}}
+{{- $global := .Values.global | default dict -}}
+{{- if hasKey $global "ingressClassName" -}}
+{{- $global.ingressClassName -}}
+{{- else -}}
+{{- .Values.ingressClassName | default "nginx" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.flowAutomation" -}}
+{{- $globalFlow := (.Values.global | default dict).flowAutomation | default dict -}}
+{{- if $globalFlow -}}
+{{- toYaml (mergeOverwrite (deepCopy (.Values.flowAutomation | default dict)) $globalFlow) -}}
+{{- else -}}
+{{- toYaml .Values.flowAutomation -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mergedGlobalValues.image" -}}
+{{- $imageRegistry := include "mergedGlobalValues.imageRegistry" . -}}
+{{- if $imageRegistry }}
+{{- printf "%s/%s:%s" $imageRegistry .Values.image.repository .Values.image.tag -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+{{- end -}}

--- a/agent-web/charts/agent-web/templates/deployment.yaml
+++ b/agent-web/charts/agent-web/templates/deployment.yaml
@@ -1,10 +1,12 @@
+{{- $env := include "mergedGlobalValues.env" . | fromYaml -}}
+{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.image.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ include "mergedGlobalValues.replicaCount" . }}
   selector:
     matchLabels:
       app: {{ .Values.image.name }}
@@ -24,7 +26,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ include "mergedGlobalValues.image" . }}"
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/agent-web/charts/agent-web/templates/ingress.yaml
+++ b/agent-web/charts/agent-web/templates/ingress.yaml
@@ -1,11 +1,12 @@
 ---
+{{- $depServices := include "mergedGlobalValues.depServices" . | fromYaml -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.moduleName }}-ingress
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
-  ingressClassName: {{ index .Values.depServices "class-443" "ingressClass" }}
+  ingressClassName: {{ index $depServices "class-443" "ingressClass" }}
   rules:
     - http:
         paths:

--- a/agent-web/charts/agent-web/templates/post-delete-job.yaml
+++ b/agent-web/charts/agent-web/templates/post-delete-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-post-delete-job
+  name: {{ .Values.image.name }}-post-delete-job
   labels:
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}
@@ -14,7 +14,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: {{ .Release.Name }}
+      name: {{ .Values.image.name }}-post-delete
       labels:
         release: {{ .Release.Name }}
         chart: {{ .Chart.Name }}
@@ -23,7 +23,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: post-delete-job
-          image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ include "mergedGlobalValues.image" . }}
           command:
             - "sh"
             - "-c"

--- a/agent-web/charts/agent-web/templates/post-install-job.yaml
+++ b/agent-web/charts/agent-web/templates/post-install-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-post-install-job
+  name: {{ .Values.image.name }}-post-install-job
   labels:
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}
@@ -14,7 +14,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: {{ .Release.Name }}
+      name: {{ .Values.image.name }}-post-install
       labels:
         release: {{ .Release.Name }}
         chart: {{ .Chart.Name }}
@@ -23,7 +23,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: post-install-job
-          image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ include "mergedGlobalValues.image" . }}
           command:
             - "sh"
             - "-c"

--- a/agent-web/charts/agent-web/templates/service.yaml
+++ b/agent-web/charts/agent-web/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.image.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   {{- if .Values.service.enableDualStack }}
   ipFamilyPolicy: PreferDualStack


### PR DESCRIPTION
## Summary
- add umbrella-compatible helper functions for decision-agent charts
- rename legacy agent-backend resources to stable non-conflicting names and fix internal references
- update agent-web hook names and globals handling for umbrella installs

## Test Plan
- helm template test ./agent-backend/deploy/helm/agent-backend
- helm template test ./agent-web/charts/agent-web